### PR TITLE
Environment Flag and Exclude Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Python library to keep projects updated on clients machines
 
-**Pip Install Globally:** `pip install git+https://github.com/Trogiken/PyUpdate`
+**Pip Install:** `pip install git+https://github.com/Trogiken/PyUpdate`
 
 ## Getting Started
 
 Build your project using the PyUpdate CLI and upload it.
 
-`pyupdate -f absolute/path/to/project`
+`pyupdate -f absolute/path/to/project -no_env`
 
 Importing PyUpdate and initialize the UpdateManager object.
 

--- a/pyupdate/main_cli.py
+++ b/pyupdate/main_cli.py
@@ -9,6 +9,7 @@ def cli():
     """PyUpdate CLI"""
     parser = argparse.ArgumentParser(description='PyUpdate CLI')
     parser.add_argument('-p', '--project', help="Path to project folder", required=True)
+    parser.add_argument('-no_env', help="Exclude Evironment Directories", action='store_true')
     parser.add_argument('-e', '--exclude', help="Exclude files and directories", nargs='+', default=[])
     args = parser.parse_args()
     
@@ -17,7 +18,7 @@ def cli():
         sys.exit(1)
     
     try:
-        builder = util.Builder(project_path=args.project, exclude_paths=args.exclude)
+        builder = util.Builder(project_path=args.project, exclude_envs=args.no_env, exclude_paths=args.exclude)
         builder.build()
     except Exception as error:
         raise BuildError(error)

--- a/pyupdate/main_cli.py
+++ b/pyupdate/main_cli.py
@@ -17,9 +17,6 @@ def cli():
         print(f'Folder "{args.project}" does not exist')
         sys.exit(1)
     
-    # DEBUG
-    print(args.no_env)
-    
     try:
         builder = util.Builder(project_path=args.project, exclude_envs=args.no_env, exclude_paths=args.exclude)
         builder.build()

--- a/pyupdate/main_cli.py
+++ b/pyupdate/main_cli.py
@@ -17,6 +17,9 @@ def cli():
         print(f'Folder "{args.project}" does not exist')
         sys.exit(1)
     
+    # DEBUG
+    print(args.no_env)
+    
     try:
         builder = util.Builder(project_path=args.project, exclude_envs=args.no_env, exclude_paths=args.exclude)
         builder.build()

--- a/pyupdate/utilities/build.py
+++ b/pyupdate/utilities/build.py
@@ -159,4 +159,7 @@ class Builder:
         if self.exclude_envs:
             excluded_paths += [os.path.join(self.project_path, path) for path in self.env_names]
         
+        # DEBUG
+        print(excluded_paths)
+        
         hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths)

--- a/pyupdate/utilities/build.py
+++ b/pyupdate/utilities/build.py
@@ -152,14 +152,10 @@ class Builder:
         print(f'Creating hash database at "{self._hash_db_path}"')
         hasher = hashing.Hasher(project_name=os.path.basename(self.project_path))
 
-        # DEBUG Exclude paths need more testing
         excluded_paths = [self._pyudpdate_folder]
         if self.exclude_paths:
             excluded_paths += self.exclude_paths
         if self.exclude_envs:
             excluded_paths += [os.path.join(self.project_path, path) for path in self.env_names]
-        
-        # DEBUG
-        print(excluded_paths)
-        
+
         hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths)

--- a/pyupdate/utilities/build.py
+++ b/pyupdate/utilities/build.py
@@ -44,9 +44,29 @@ class Builder:
     build() -> None
         Builds the project
     """
-    def __init__(self, project_path: str, exclude_paths: list):
+    def __init__(self, project_path: str, exclude_envs: bool = False, exclude_paths: list = []):
         self.project_path = project_path
+        self.exclude_envs = exclude_envs
         self.exclude_paths = exclude_paths
+
+        self.env_names = [
+            '.venv',
+            'venv',
+            'env',
+            '.env',
+            '.virtualenv',
+            'virtualenv',
+            'conda',
+            '.conda',
+            'condaenv',
+            '.condaenv',
+            'pipenv',
+            '.pipenv',
+            'poetry',
+            '.poetry',
+            'pyenv',
+            '.pyenv'
+        ]
 
         self._pyudpdate_folder = None
         self._config_path = None
@@ -133,5 +153,10 @@ class Builder:
         hasher = hashing.Hasher(project_name=os.path.basename(self.project_path))
 
         # DEBUG Exclude paths need more testing
-        excluded_paths = [self._pyudpdate_folder] + self.exclude_paths
+        excluded_paths = [self._pyudpdate_folder]
+        if self.exclude_paths:
+            excluded_paths += self.exclude_paths
+        if self.exclude_envs:
+            excluded_paths += [os.path.join(self.project_path, path) for path in self.env_names]
+        
         hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths)

--- a/pyupdate/utilities/hashing.py
+++ b/pyupdate/utilities/hashing.py
@@ -87,15 +87,10 @@ class Hasher:
             os.remove(db_save_path)
         
         exclude_paths = helper.normalize_paths(exclude_paths)
-        # DEBUG
-        print(exclude_paths)
+
         # separate files and directors from exclude_paths
         exclude_file_paths = [path for path in exclude_paths if os.path.isfile(path)]
         exclude_dir_paths = [path for path in exclude_paths if os.path.isdir(path)]
-
-        # DEBUG
-        print(f"Exclude file paths: {exclude_file_paths}")
-        print(f"Exclude dir paths: {exclude_dir_paths}")
 
         connection = sqlite3.connect(db_save_path)
         cursor = connection.cursor()
@@ -113,13 +108,10 @@ class Hasher:
         # Create a pool, default number of processes is the number of cores on the machine
         with Pool() as pool:
             start_time = time.time()  # Start timer
-            # DEBUG
-            print("Start of Pool")
+
             for root, dirs, files in os.walk(hash_dir_path):
                 if exclude_dir_paths:
-                    if any([path in root for path in exclude_dir_paths]):
-                        # DEBUG
-                        print(f"Root path exclude block: {root}")
+                    if any(exclude_dir_path in helper.normalize_paths(root) for exclude_dir_path in exclude_dir_paths):  # If the root directory is in the exclude directories
                         dirs[:] = []  # Skip subdirectories
                         continue
                 
@@ -127,13 +119,9 @@ class Hasher:
                 file_paths = helper.normalize_paths([os.path.join(root, file) for file in files])
 
                 if exclude_file_paths:
-                    # DEBUG
-                    print(f"Second exclude path block")
                     for path in exclude_file_paths:
                         if path in file_paths:
                             file_paths.remove(path)
-                            # DEBUG
-                            print(f"File removed: {path}")
                 
                 results = pool.map(self.create_hash, file_paths)  # Use workers to create hashes
                 batch_data.extend(results)

--- a/pyupdate/utilities/hashing.py
+++ b/pyupdate/utilities/hashing.py
@@ -94,6 +94,10 @@ class Hasher:
         """Create a hash database from a directory path and save it to a file path. Return the save file path."""
         if os.path.exists(db_save_path):
             os.remove(db_save_path)
+        
+        # separate files and directors from exclude_paths
+        exclude_file_paths = [os.path.isfile(path) for path in exclude_paths]
+        exclude_dir_paths = [os.path.isdir(path) for path in exclude_paths]
 
         connection = sqlite3.connect(db_save_path)
         cursor = connection.cursor()
@@ -113,21 +117,23 @@ class Hasher:
             start_time = time.time()  # Start timer
             # DEBUG
             print("Start of Pool")
-            for root, _, files in os.walk(hash_dir_path):
-                if root in exclude_paths:
-                    # DEBUG
-                    print(f"Root path exclude block: {root}")
-                    continue
+            for root, dirs, files in os.walk(hash_dir_path):
+                if exclude_dir_paths:
+                    if any(exclude_dir_path in root for exclude_dir_path in exclude_dir_paths):  # If the root path contains an excluded directory path
+                        # DEBUG
+                        print(f"Root path exclude block: {root}")
+                        dirs[:] = []  # Skip subdirectories
+                        continue
                 
                 # Get file paths
                 file_paths = [os.path.join(root, file) for file in files]
                 # Replace backslashes with forward slashes for consistency
                 file_paths = [file_path.replace('\\', '/') for file_path in file_paths]
 
-                if exclude_paths:
+                if exclude_file_paths:
                     # DEBUG
                     print(f"Second exclude path block")
-                    for path in exclude_paths:
+                    for path in exclude_file_paths:
                         if path in file_paths:
                             file_paths.remove(path)
                             # DEBUG

--- a/pyupdate/utilities/hashing.py
+++ b/pyupdate/utilities/hashing.py
@@ -111,8 +111,12 @@ class Hasher:
         # Create a pool, default number of processes is the number of cores on the machine
         with Pool() as pool:
             start_time = time.time()  # Start timer
+            # DEBUG
+            print("Start of Pool")
             for root, _, files in os.walk(hash_dir_path):
                 if root in exclude_paths:
+                    # DEBUG
+                    print(f"Root path exclude block: {root}")
                     continue
                 
                 # Get file paths
@@ -121,9 +125,13 @@ class Hasher:
                 file_paths = [file_path.replace('\\', '/') for file_path in file_paths]
 
                 if exclude_paths:
+                    # DEBUG
+                    print(f"Second exclude path block")
                     for path in exclude_paths:
                         if path in file_paths:
                             file_paths.remove(path)
+                            # DEBUG
+                            print(f"File removed: {path}")
                 
                 results = pool.map(self.create_hash, file_paths)  # Use workers to create hashes
                 batch_data.extend(results)

--- a/pyupdate/utilities/hashing.py
+++ b/pyupdate/utilities/hashing.py
@@ -96,8 +96,12 @@ class Hasher:
             os.remove(db_save_path)
         
         # separate files and directors from exclude_paths
-        exclude_file_paths = [os.path.isfile(path) for path in exclude_paths]
-        exclude_dir_paths = [os.path.isdir(path) for path in exclude_paths]
+        exclude_file_paths = [path for path in exclude_paths if os.path.isfile(path)]
+        exclude_dir_paths = [path for path in exclude_paths if os.path.isdir(path)]
+
+        # DEBUG
+        print(f"Exclude file paths: {exclude_file_paths}")
+        print(f"Exclude dir paths: {exclude_dir_paths}")
 
         connection = sqlite3.connect(db_save_path)
         cursor = connection.cursor()
@@ -119,7 +123,7 @@ class Hasher:
             print("Start of Pool")
             for root, dirs, files in os.walk(hash_dir_path):
                 if exclude_dir_paths:
-                    if any(exclude_dir_path in root for exclude_dir_path in exclude_dir_paths):  # If the root path contains an excluded directory path
+                    if root in exclude_dir_paths:
                         # DEBUG
                         print(f"Root path exclude block: {root}")
                         dirs[:] = []  # Skip subdirectories

--- a/pyupdate/utilities/hashing.py
+++ b/pyupdate/utilities/hashing.py
@@ -10,6 +10,7 @@ import sqlite3
 import time
 from multiprocessing import Pool
 from dataclasses import dataclass
+from pyupdate.utilities import helper
 
 
 @dataclass
@@ -48,22 +49,12 @@ class Hasher:
         The name of the project directory (Not the full path)
 
     Methods:
-    - get_relative_path(self, file_path: str) -> str: Returns the relative path of a file path.
     - create_hash(self, file_path: str) -> (str, str): Creates a hash from file bytes using the chunk method and returns the relative file path and hash as a string.
     - create_hash_db(self, hash_dir_path: str, db_save_path: str, exclude_paths=[]) -> str: Creates a hash database from a directory path and saves it to a file path. Returns the file path.
     - compare_databases(self, local_db_path: str, cloud_db_path: str) -> DBSummary: Compares two hash databases and returns a summary of the differences.
     """
     def __init__(self, project_name: str):
         self.project_name = project_name
-    
-    def get_relative_path(self, file_path: str) -> str:
-        """Get the relative path of a file path."""
-        proj_index = file_path.find(self.project_name)
-        if proj_index != -1:
-            relative_file_path = file_path[proj_index:]
-        else:
-            raise ValueError(f"Project name '{self.project_name}' not found in file path '{file_path}'")
-        return relative_file_path
 
     def create_hash(self, file_path: str) -> (str, str):
         """Create hash from file bytes using the chunk method, return relative file path and hash as a string."""
@@ -83,7 +74,7 @@ class Hasher:
                         break
                     hasher.update(chunk)
 
-            relative_file_path = self.get_relative_path(file_path)
+            relative_file_path = helper.relative_path(self.project_name, file_path)
             file_hash = hasher.hexdigest()
             
             return relative_file_path, file_hash
@@ -95,6 +86,7 @@ class Hasher:
         if os.path.exists(db_save_path):
             os.remove(db_save_path)
         
+        exclude_paths = helper.normalize_paths(exclude_paths)
         # separate files and directors from exclude_paths
         exclude_file_paths = [path for path in exclude_paths if os.path.isfile(path)]
         exclude_dir_paths = [path for path in exclude_paths if os.path.isdir(path)]
@@ -130,9 +122,7 @@ class Hasher:
                         continue
                 
                 # Get file paths
-                file_paths = [os.path.join(root, file) for file in files]
-                # Replace backslashes with forward slashes for consistency
-                file_paths = [file_path.replace('\\', '/') for file_path in file_paths]
+                file_paths = helper.normalize_paths([os.path.join(root, file) for file in files])
 
                 if exclude_file_paths:
                     # DEBUG

--- a/pyupdate/utilities/hashing.py
+++ b/pyupdate/utilities/hashing.py
@@ -87,6 +87,8 @@ class Hasher:
             os.remove(db_save_path)
         
         exclude_paths = helper.normalize_paths(exclude_paths)
+        # DEBUG
+        print(exclude_paths)
         # separate files and directors from exclude_paths
         exclude_file_paths = [path for path in exclude_paths if os.path.isfile(path)]
         exclude_dir_paths = [path for path in exclude_paths if os.path.isdir(path)]
@@ -115,7 +117,7 @@ class Hasher:
             print("Start of Pool")
             for root, dirs, files in os.walk(hash_dir_path):
                 if exclude_dir_paths:
-                    if root in exclude_dir_paths:
+                    if any([path in root for path in exclude_dir_paths]):
                         # DEBUG
                         print(f"Root path exclude block: {root}")
                         dirs[:] = []  # Skip subdirectories

--- a/pyupdate/utilities/helper.py
+++ b/pyupdate/utilities/helper.py
@@ -3,6 +3,21 @@ import yaml
 import requests
 
 
+def normalize_paths(path_list: list) -> list:
+    """Replace back with forward slashes in a list of paths"""
+    return [path.replace('\\', '/') for path in path_list]
+
+
+def relative_path(relative_name: str, file_path: str) -> str:
+    """Use relative_name to form a relative file path from file_path"""
+    name_index = file_path.find(relative_name)
+    if name_index != -1:
+        relative_file_path = file_path[name_index:]
+    else:
+        raise ValueError(f"Relative name '{relative_name}' not found in file path '{file_path}'")
+    return relative_file_path
+
+
 class Config:
     """
     Config helper class

--- a/pyupdate/utilities/helper.py
+++ b/pyupdate/utilities/helper.py
@@ -1,11 +1,17 @@
 import os
 import yaml
 import requests
+from typing import List, Union
 
 
-def normalize_paths(path_list: list) -> list:
-    """Replace back with forward slashes in a list of paths"""
-    return [path.replace('\\', '/') for path in path_list]
+def normalize_paths(paths: Union[str, List[str]]) -> List[str]:
+    """Replace backslashes with forward slashes in a path or a list of paths"""
+    if isinstance(paths, str):
+        return paths.replace('\\', '/')
+    elif isinstance(paths, list):
+        return [path.replace('\\', '/') for path in paths]
+    else:
+        raise TypeError("Input must be a string or a list of strings")
 
 
 def relative_path(relative_name: str, file_path: str) -> str:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='pyupdate',
-    version='0.2.4',
+    version='0.2.5',
     author='Noah Blaszak',
     author_email='70231827+Trogiken@users.noreply.github.com',
     description='Python library that allows the version of a program to be updated.',


### PR DESCRIPTION
## New

* The new `no_env` flag appends a list of common python environments to the exclude paths. The list can be found in `build.Builder()`.
* `helper.normalize_paths` function accepts a string or a list of strings. Returns these same strings but with all backslashes being changed to forward slashes.
* `helper.relative_path` function accepts two strings, a relative name and a file path. Finds the relative name in the file path and returns a sliced string containing the relative name and anything that comes after it.

## Fixes

* Logic in the create_hash_db function that exclude file and directory paths have been tuned and tested.