### PR TITLE
Hidden and Patterns Flag with Regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Python library to keep projects updated on clients machines
 
 ## Getting Started
 
-Build your project using the PyUpdate CLI and upload it.
+Build your project using the PyUpdate CLI and upload it. Use the _-h_ flag to see a list of options.
 
-`pyupdate -f absolute/path/to/project -no_env`
+`pyupdate -f absolute/path/to/project -no_hidden`
 
 Importing PyUpdate and initialize the UpdateManager object.
 

--- a/pyupdate/main_cli.py
+++ b/pyupdate/main_cli.py
@@ -8,10 +8,11 @@ from pyupdate.utilities.build import BuildError
 def cli():
     """PyUpdate CLI"""
     parser = argparse.ArgumentParser(description='PyUpdate CLI')
-    parser.add_argument('-p', '--project', help="Path to project folder", required=True)
-    parser.add_argument('-no_env', help="Exclude Evironment Directories", action='store_true')
+    parser.add_argument('-p', '--project', help="Absolute path to project folder", required=True)
+    parser.add_argument('-no_env', help="Exclude evironment directories", action='store_true')
     parser.add_argument('-no_hidden', help="Exclude hidden files and directories", action='store_true')
-    parser.add_argument('-e', '--exclude', help="Exclude files and directories", nargs='+', default=[])
+    parser.add_argument('-patterns', help="Exclude files and directories using regex patterns", nargs='+', default=[])
+    parser.add_argument('-e', '--exclude', help="Absolute paths for excluded files and directories", nargs='+', default=[])
     args = parser.parse_args()
     
     if not os.path.exists(args.project):
@@ -19,7 +20,7 @@ def cli():
         sys.exit(1)
     
     try:
-        builder = util.Builder(project_path=args.project, exclude_envs=args.no_env, exclude_hidden=args.no_hidden, exclude_paths=args.exclude)
+        builder = util.Builder(project_path=args.project, exclude_envs=args.no_env, exclude_hidden=args.no_hidden, exclude_patterns=args.patterns, exclude_paths=args.exclude)
         builder.build()
     except Exception as error:
         raise BuildError(error)

--- a/pyupdate/main_cli.py
+++ b/pyupdate/main_cli.py
@@ -10,7 +10,7 @@ def cli():
     parser = argparse.ArgumentParser(description='PyUpdate CLI')
     parser.add_argument('-p', '--project', help="Path to project folder", required=True)
     parser.add_argument('-no_env', help="Exclude Evironment Directories", action='store_true')
-    parser.add_argument('no_hidden', help="Exclude hidden files and directories", action='store_true')
+    parser.add_argument('-no_hidden', help="Exclude hidden files and directories", action='store_true')
     parser.add_argument('-e', '--exclude', help="Exclude files and directories", nargs='+', default=[])
     args = parser.parse_args()
     

--- a/pyupdate/main_cli.py
+++ b/pyupdate/main_cli.py
@@ -10,6 +10,7 @@ def cli():
     parser = argparse.ArgumentParser(description='PyUpdate CLI')
     parser.add_argument('-p', '--project', help="Path to project folder", required=True)
     parser.add_argument('-no_env', help="Exclude Evironment Directories", action='store_true')
+    parser.add_argument('no_hidden', help="Exclude hidden files and directories", action='store_true')
     parser.add_argument('-e', '--exclude', help="Exclude files and directories", nargs='+', default=[])
     args = parser.parse_args()
     
@@ -18,7 +19,7 @@ def cli():
         sys.exit(1)
     
     try:
-        builder = util.Builder(project_path=args.project, exclude_envs=args.no_env, exclude_paths=args.exclude)
+        builder = util.Builder(project_path=args.project, exclude_envs=args.no_env, exclude_hidden=args.no_hidden, exclude_paths=args.exclude)
         builder.build()
     except Exception as error:
         raise BuildError(error)

--- a/pyupdate/utilities/build.py
+++ b/pyupdate/utilities/build.py
@@ -44,10 +44,11 @@ class Builder:
     build() -> None
         Builds the project
     """
-    def __init__(self, project_path: str, exclude_envs: bool = False, exclude_paths: list = []):
+    def __init__(self, project_path: str, exclude_envs: bool = False, exclude_hidden: bool = False, exclude_paths: list = []):
         self.project_path = project_path
         self.exclude_envs = exclude_envs
         self.exclude_paths = exclude_paths
+        self.exclude_hidden = exclude_hidden
 
         self.env_names = [
             '.venv',
@@ -157,5 +158,7 @@ class Builder:
             excluded_paths += self.exclude_paths
         if self.exclude_envs:
             excluded_paths += [os.path.join(self.project_path, path) for path in self.env_names]
-
-        hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths)
+        if self.exclude_hidden:
+            hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths, ['.*/.*'])
+        else:
+            hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths)

--- a/pyupdate/utilities/build.py
+++ b/pyupdate/utilities/build.py
@@ -159,6 +159,6 @@ class Builder:
         if self.exclude_envs:
             excluded_paths += [os.path.join(self.project_path, path) for path in self.env_names]
         if self.exclude_hidden:
-            hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths, ['.*/', '.*'])
+            hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths, [r'.*/\..*'])
         else:
             hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths)

--- a/pyupdate/utilities/build.py
+++ b/pyupdate/utilities/build.py
@@ -159,6 +159,6 @@ class Builder:
         if self.exclude_envs:
             excluded_paths += [os.path.join(self.project_path, path) for path in self.env_names]
         if self.exclude_hidden:
-            hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths, ['.*/.*'])
+            hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths, ['.*/', '.*'])
         else:
             hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths)

--- a/pyupdate/utilities/build.py
+++ b/pyupdate/utilities/build.py
@@ -48,11 +48,13 @@ class Builder:
     build() -> None
         Builds the project
     """
-    def __init__(self, project_path: str, exclude_envs: bool = False, exclude_hidden: bool = False, exclude_paths: list = []):
+    def __init__(self, project_path: str, exclude_envs: bool = False, exclude_hidden: bool = False, exclude_patterns: list = [], exclude_paths: list = []):
         self.project_path = project_path
         self.exclude_envs = exclude_envs
-        self.exclude_paths = exclude_paths
         self.exclude_hidden = exclude_hidden
+        self.exclude_patterns = exclude_patterns
+        self.exclude_paths = exclude_paths
+
 
         self.env_names = [
             '.venv',
@@ -158,11 +160,11 @@ class Builder:
         hasher = hashing.Hasher(project_name=os.path.basename(self.project_path))
 
         excluded_paths = [self._pyudpdate_folder]
+        if self.exclude_hidden:
+            self.exclude_patterns.append(r'.*/\..*')
         if self.exclude_paths:
             excluded_paths += self.exclude_paths
         if self.exclude_envs:
             excluded_paths += [os.path.join(self.project_path, path) for path in self.env_names]
-        if self.exclude_hidden:
-            hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths, [r'.*/\..*'])
-        else:
-            hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths)
+            
+        hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths, self.exclude_patterns)

--- a/pyupdate/utilities/build.py
+++ b/pyupdate/utilities/build.py
@@ -37,6 +37,10 @@ class Builder:
     Attributes:
     project_path: str
         Path to the project folder
+    exclude_envs: bool
+        Whether to exclude common virtual environment folders
+    exclude_hidden: bool
+        Whether to exclude hidden files and folders
     exclude_paths: list
         List of absolute paths to exclude from the hash database
     

--- a/pyupdate/utilities/build.py
+++ b/pyupdate/utilities/build.py
@@ -159,12 +159,12 @@ class Builder:
         print(f'Creating hash database at "{self._hash_db_path}"')
         hasher = hashing.Hasher(project_name=os.path.basename(self.project_path))
 
-        excluded_paths = [self._pyudpdate_folder]
+        self.exclude_paths.append(self._pyudpdate_folder)
+        self.exclude_patterns.append(r'.*/__pycache__/.*')
+
         if self.exclude_hidden:
             self.exclude_patterns.append(r'.*/\..*')
-        if self.exclude_paths:
-            excluded_paths += self.exclude_paths
         if self.exclude_envs:
-            excluded_paths += [os.path.join(self.project_path, path) for path in self.env_names]
-            
-        hasher.create_hash_db(self.project_path, self._hash_db_path, excluded_paths, self.exclude_patterns)
+            self.exclude_paths += [os.path.join(self.project_path, path) for path in self.env_names]
+
+        hasher.create_hash_db(self.project_path, self._hash_db_path, self.exclude_paths, self.exclude_patterns)

--- a/pyupdate/utilities/hashing.py
+++ b/pyupdate/utilities/hashing.py
@@ -51,7 +51,7 @@ class Hasher:
 
     Methods:
     - create_hash(self, file_path: str) -> (str, str): Creates a hash from file bytes using the chunk method and returns the relative file path and hash as a string.
-    - create_hash_db(self, hash_dir_path: str, db_save_path: str, exclude_paths=[]) -> str: Creates a hash database from a directory path and saves it to a file path. Returns the file path.
+    - create_hash_db(self, hash_dir_path: str, db_save_path: str, exclude_paths=[], wildcards=[]) -> str: Creates a hash database from a directory path and saves it to a file path. Returns the file path.
     - compare_databases(self, local_db_path: str, cloud_db_path: str) -> DBSummary: Compares two hash databases and returns a summary of the differences.
     """
     def __init__(self, project_name: str):
@@ -112,17 +112,18 @@ class Hasher:
 
             for root, dirs, files in os.walk(hash_dir_path):
                 if exclude_dir_paths:
-                    if any(exclude_dir_path in helper.normalize_paths(root) for exclude_dir_path in exclude_dir_paths):  # If the root directory is in the exclude directories
+                    # If the root directory is in the exclude directories
+                    if any(exclude_dir_path in helper.normalize_paths(root) for exclude_dir_path in exclude_dir_paths):
                         dirs[:] = []  # Skip subdirectories
                         continue
                 
                 if wildcards:
-                    # if anay directory in the root matches a wildcard, skip it
+                    # if any directory in the root matches a wildcard, skip it
                     if any(re.search(wildcard, helper.normalize_paths(root)) for wildcard in wildcards):
-                        dirs[:] = []
+                        dirs[:] = []  # Skip subdirectories
                         continue
                 
-                file_paths = helper.normalize_paths([os.path.join(root, file) for file in files])
+                file_paths = helper.normalize_paths([os.path.join(root, file) for file in files])  # Get full file paths
 
                 if exclude_file_paths:
                     for path in exclude_file_paths:
@@ -130,6 +131,7 @@ class Hasher:
                             file_paths.remove(path)
                 
                 if wildcards:
+                    # if any file in the root matches a wildcard, skip it
                     file_paths = [
                         path
                         for path in file_paths

--- a/pyupdate/utilities/hashing.py
+++ b/pyupdate/utilities/hashing.py
@@ -51,7 +51,7 @@ class Hasher:
 
     Methods:
     - create_hash(self, file_path: str) -> (str, str): Creates a hash from file bytes using the chunk method and returns the relative file path and hash as a string.
-    - create_hash_db(self, hash_dir_path: str, db_save_path: str, exclude_paths=[], wildcards=[]) -> str: Creates a hash database from a directory path and saves it to a file path. Returns the file path.
+    - create_hash_db(self, hash_dir_path: str, db_save_path: str, exclude_paths=[], exclude_patterns=[]) -> str: Creates a hash database from a directory path and saves it to a file path. Returns the file path.
     - compare_databases(self, local_db_path: str, cloud_db_path: str) -> DBSummary: Compares two hash databases and returns a summary of the differences.
     """
     def __init__(self, project_name: str):
@@ -82,7 +82,7 @@ class Hasher:
         except Exception as error:
             raise HashingError(f"Error hashing file '{file_path}' | {error}")
 
-    def create_hash_db(self, hash_dir_path: str, db_save_path: str, exclude_paths=[], wildcards=[]) -> str:
+    def create_hash_db(self, hash_dir_path: str, db_save_path: str, exclude_paths=[], exclude_patterns=[]) -> str:
         """Create a hash database from a directory path and save it to a file path. Return the save file path."""
         if os.path.exists(db_save_path):
             os.remove(db_save_path)
@@ -117,9 +117,9 @@ class Hasher:
                         dirs[:] = []  # Skip subdirectories
                         continue
                 
-                if wildcards:
-                    # if any directory in the root matches a wildcard, skip it
-                    if any(re.search(wildcard, helper.normalize_paths(root)) for wildcard in wildcards):
+                if exclude_patterns:
+                    # if any directory in the root matches a pattern, skip it
+                    if any(re.search(pattern, helper.normalize_paths(root)) for pattern in exclude_patterns):
                         dirs[:] = []  # Skip subdirectories
                         continue
                 
@@ -130,12 +130,12 @@ class Hasher:
                         if path in file_paths:
                             file_paths.remove(path)
                 
-                if wildcards:
-                    # if any file in the root matches a wildcard, skip it
+                if exclude_patterns:
+                    # if any file in the root matches a pattern, skip it
                     file_paths = [
                         path
                         for path in file_paths
-                        if not any(re.search(wildcard, path) for wildcard in wildcards)
+                        if not any(re.search(pattern, path) for pattern in exclude_patterns)
                     ]
                 
                 results = pool.map(self.create_hash, file_paths)  # Use workers to create hashes

--- a/pyupdate/utilities/hashing.py
+++ b/pyupdate/utilities/hashing.py
@@ -128,7 +128,7 @@ class Hasher:
                     file_paths = [
                         path
                         for path in file_paths
-                        if any(fnmatch.fnmatch(path, wildcard) for wildcard in wildcards)
+                        if not any(fnmatch.fnmatch(path, wildcard) for wildcard in wildcards)
                     ]
                 
                 results = pool.map(self.create_hash, file_paths)  # Use workers to create hashes

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='pyupdate',
-    version='0.2.5',
+    version='0.2.6',
     author='Noah Blaszak',
     author_email='70231827+Trogiken@users.noreply.github.com',
     description='Python library that allows the version of a program to be updated.',


### PR DESCRIPTION
## New
* The `-no_hidden` flag has been added to skip all files and directories that begin with a period.
* The `-patterns` flag has been added to allow for the ability to use regex patterns to filter out files and directories. Multiple patterns can be used.

## Update
* Pycache folders are automatically filtered when creating the hash db
* Misc docstuff